### PR TITLE
Update `libm` to version 0.2.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/copterust/dcmimu"
 readme = "README.md"
 
 [dependencies]
-libm = "0.1.2"
+libm = "0.2.11"
 
 [dev-dependencies]
 csv = "1.0.0"


### PR DESCRIPTION
This PR updates `libm` to its most recent version.

I'm using `DCMIMU` in a large-ish project, and running that with this PR instead of the current master branch produces exactly the same results, so I'm quite confident that this update does not change the results of this crate in any way.