### PR TITLE
Make `DCMIMU::new` a `const fn`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ const INITIAL_BIAS_VARIANCE: f32 = 0.1 * 0.1;
 
 impl DCMIMU {
     /// New
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         #[cfg_attr(rustfmt, rustfmt_skip)]
         DCMIMU {
             g0: GRAVITY,


### PR DESCRIPTION
This tiny change allows `DCMIMU` to be used statics, e.g.:

```rust
static IMU: Mutex<RefCell<DCMIMU>> = Mutex::new(RefCell::new(DCMIMU::new()));
```