### PR TITLE
Fix `usage` example

### DIFF
--- a/examples/usage.rs
+++ b/examples/usage.rs
@@ -4,5 +4,5 @@ use dcmimu::DCMIMU;
 
 fn main() {
     let mut imu = DCMIMU::new();
-    imu.update(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.1);
+    imu.update((0.0, 0.0, 0.0), (0.0, 0.0, 0.0), 0.1);
 }


### PR DESCRIPTION
The `usage` example did not compile.