### PR TITLE
Performance improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,26 +19,22 @@ Leave a comment in the linked issue to [raise awareness](https://www.youtube.com
 Library is available via crates.io [![crates.io](http://meritbadge.herokuapp.com/dcmimu?style=flat-square)](https://crates.io/crates/dcmimu).
 
 ```rust
-
-# Create DCMIMU:
+// Create DCMIMU:
 let mut dcmimu = DCMIMU::new();
 let mut prev_t_ms = now();
 loop {
-    # get gyroscope and accelerometer measurement from your sensors:
+    // get gyroscope and accelerometer measurement from your sensors:
     let gyro = sensor.read_gyro();
     let accel = sensor.read_accel();
-    # Convert measurements to SI if needed.
-    # Get time difference since last update:
+    // Convert measurements to SI if needed.
+    // Get time difference since last update:
     let t_ms = now();
     let dt_ms = t_ms - prev_t_ms
     prev_t_ms = t_ms
-    # Update dcmimu states (don't forget to use SI):
-    let (dcm, _gyro_biases) = dcmimu.update((gyro.x, gyro.y, gyro.z),
-                                            (accel.x, accel.y, accel.z),
-                                            dt_ms.seconds());
+    // Update dcmimu states (don't forget to use SI):
+    dcmimu.update((gyro.x, gyro.y, gyro.z), (accel.x, accel.y, accel.z), dt_ms.seconds());
+    let dcm = dcmimu.to_euler_angles();
     println!("Roll: {}; yaw: {}; pitch: {}", dcm.roll, dcm.yaw, dcm.pitch);
-    # Measurements can also be queried without updating:
-    println!("{:?} == {}, {}, {}", dcmimu.all(), dcmimu.roll(), dcmimu.yaw(), dcmimu.pitch());
 }
 
 ```

--- a/examples/from_csv.rs
+++ b/examples/from_csv.rs
@@ -61,11 +61,12 @@ fn main() {
         let dt = if prev_t == 0.0 { 0.00 } else { time - prev_t };
         prev_t = time;
         dcmimu.update((gx, gy, gz), (ax, ay, az), dt as f32);
+        let euer_angles = dcmimu.to_euler_angles();
         println!(
             "{:2.8},{:2.8},{:2.8},{:2.8},{:2.8},{:2.8}",
-            dcmimu.yaw(),
-            dcmimu.pitch(),
-            dcmimu.roll(),
+            euer_angles.yaw,
+            euer_angles.pitch,
+            euer_angles.roll,
             y,
             p,
             r

--- a/examples/from_spaces.rs
+++ b/examples/from_spaces.rs
@@ -37,7 +37,8 @@ fn main() {
             parse_float(vec[8]),
             parse_float(vec[9]),
         );
-        let (ypr, _gyro_biases) = dcmimu.update((gx, gy, gz), (ax, ay, az), dt_s);
+        dcmimu.update((gx, gy, gz), (ax, ay, az), dt_s);
+        let ypr = dcmimu.to_euler_angles();
 
         for f in [ypr.yaw, ypr.pitch, ypr.roll, ry, rp, rr].into_iter() {
             let mut b = ryu::Buffer::new();


### PR DESCRIPTION
This PR changes the behavior of `update` such that the current estimates (roll, pitch, yaw) are not returned from this method anymore but instead have to be explicitly queried with another method call.

The reason is that computing roll, pitch, and yaw involves several expensive trigonometric functions (`sinf`, `cosf`, `asinf`, and two times `atanf`) not needed for the actual algorithm to work. However, in many applications the `update` method is called at a high rate (e.g. 500 hertz) but the actual estimates are only needed at a much lower rate (e.g. 50 herz) by downstream systems. Hence, in this example, 90% of those expensive trigonometric functions are wasted. With this PR, `update` does not do any of this anymore, but instead the user must call `to_euler_angles` to get the current estimates (previously called `all` - I renamed this method to make it clear that this is not a simple accessor anymore but instead somewhat expensive).

I did some simple benchmarks on a Cortex-M55 MCU. The "old" `update` takes 4451 cycles, wheres the new version is only 3359 cycles.
In case one needs estimates for every call to `update` one can simply call `to_euler_angles` directly afterwards, when doing this the performance is pretty much the same as the "old" `update` method.

In theory, the estimated results with this PR should not change at all, but due to finite precision numerics etc they are different. I ran this PR with a simple IMU live demo of mine, and everything looks reasonable ([video on youtube](https://www.youtube.com/watch?v=uoGsW_rH_-Q)). Still, I haven't dug deeply into how the dcmimu algorithm actually works, so please review carefully:)